### PR TITLE
Update chainID: `localterra` -> `columbus-5`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,9 @@ RUN set -eux &&\
     make -j$(nproc) &&\
     make install
 
-# Clone the desired repository
+# Clone the implementation repo
 WORKDIR /code
-RUN git clone --branch v2.3.3 --depth 1 https://github.com/classic-terra/core.git .
+RUN git clone --branch main --depth 1 https://github.com/mint-cash/terra-classic-core .
 
 # Set the GIT_COMMIT and GIT_VERSION using Git commands
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,14 +138,14 @@ RUN mkdir -p /var/lib/nginx/logs && \
 # Copy the built binary from the builder stage
 COPY --from=builder-stage-2 /go/bin/terrad /usr/local/bin/terrad
 
-# Setup for localterra
+# Setup localterra (columbus-5)
 RUN set -eux &&\
     mkdir -p /app/config && \
     mkdir -p /app/data && \
     chown -R terra:terra /app && \
-    terrad init localterra \
+    terrad init columbus-5 \
     --home /app \
-    --chain-id localterra && \
+    --chain-id columbus-5 && \
     echo '{"height": "0","round": 0,"step": 0}' > /app/data/priv_validator_state.json
 
 # Copy the Nginx configuration, entrypoint script, and Terra configuration files
@@ -174,7 +174,7 @@ EXPOSE 26657
 CMD terrad start \
     --home /app \
     --minimum-gas-prices "0.01133uluna,0.15uusd,0.104938usdr,169.77ukrw,428.571umnt,0.125ueur,0.98ucny,16.37ujpy,0.11ugbp,10.88uinr,0.19ucad,0.14uchf,0.19uaud,0.2usgd,4.62uthb,1.25usek" \
-    --moniker localterra \
+    --moniker columbus-5 \
     --p2p.upnp true \
     --rpc.laddr tcp://0.0.0.0:26657 \
     --api.enable true \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 > [!IMPORTANT]
 > This repo is a rollback of [terra-money/LocalTerra](https://github.com/terra-money/LocalTerra) to bring back support for [Terra Classic](https://github.com/terra-money/classic-core). It's the only reliable solution for developing on classic, as most faucets are currently inactive.
 
+> [!TIP]
+> We are using the chainID `columbus-5` instead of `localterra` to correctly simulate the `isClassic` behavior across multiple existing clients, such as Keplr, Station, etc.
+> Examples:
+>
+> - https://github.com/chainapsis/keplr-wallet/commit/568a643f2a653ff97d1c2d6ae914bb3f54e413ed
+> - https://github.com/terra-money/station-extension/commit/e5672a88febf98c38e0574b490cfff74baef6087#diff-f9b6f47dd0b3866f3e011e6f787cb035f6abb436bd32f4528e59cac2caf56c44R145-R149
+
 <p>&nbsp;</p>
 <p align="center">
 <img src="https://raw.githubusercontent.com/terra-money/LocalTerra/master/img/localterra_logo_with_name.svg" width=500>

--- a/oracle-feeder/index.ts
+++ b/oracle-feeder/index.ts
@@ -15,7 +15,7 @@ const {
   MAINNET_LCD_URL = 'https://terra-classic-lcd.publicnode.com',
   MAINNET_CHAIN_ID = 'columbus-5',
   TESTNET_LCD_URL = 'http://localhost:1317',
-  TESTNET_CHAIN_ID = 'localterra',
+  TESTNET_CHAIN_ID = 'columbus-5',
   MNEMONIC = 'satisfy adjust timber high purchase tuition stool faith fine install that you unaware feed domain license impose boss human eager hat rent enjoy dawn',
 } = process.env;
 

--- a/terra/genesis.json
+++ b/terra/genesis.json
@@ -1,6 +1,6 @@
 {
   "genesis_time": "2021-05-26T10:02:06.396784Z",
-  "chain_id": "localterra",
+  "chain_id": "columbus-5",
   "initial_height": "1",
   "consensus_params": {
     "block": {
@@ -460,7 +460,7 @@
               {
                 "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
                 "description": {
-                  "moniker": "localterra",
+                  "moniker": "columbus-5",
                   "identity": "",
                   "website": "",
                   "security_contact": "",

--- a/terra/genesis.json
+++ b/terra/genesis.json
@@ -484,7 +484,7 @@
                 }
               }
             ],
-            "memo": "62cd922a9d9349e790247dadd1e32947450502fb@10.10.20.74:26656",
+            "memo": "cd38dbd287fed9d001a8cc7cd8f5b53821c764b3@172.17.0.2:26656",
             "timeout_height": "0",
             "extension_options": [],
             "non_critical_extension_options": []
@@ -509,10 +509,11 @@
               "gas_limit": "200000",
               "payer": "",
               "granter": ""
-            }
+            },
+            "tip": null
           },
           "signatures": [
-            "Xb9hjzkSJus9X6scrJO2RbC2jWie7oMst6bWQuvDBrwFeTXTM7YZD4B6YyOaHep9VRQHONDl3iZqeM1oYw8PQA=="
+            "iGOOcmLXff1kYhATZzWgwaCrVyD/bdzAvkj3jS/wpvM7UAl3EVDltAXMFMZ8N+qibtuyxAQ5ebPa1NW2XpbNeA=="
           ]
         }
       ]
@@ -554,7 +555,10 @@
       "connection_genesis": {
         "connections": [],
         "client_connection_paths": [],
-        "next_connection_sequence": "0"
+        "next_connection_sequence": "0",
+        "params": {
+          "max_expected_time_per_block": "30000000000"
+        }
       },
       "channel_genesis": {
         "channels": [],
@@ -566,6 +570,37 @@
         "ack_sequences": [],
         "next_channel_sequence": "0"
       }
+    },
+    "interchainaccounts": {
+      "controller_genesis_state": {
+        "active_channels": [],
+        "interchain_accounts": [],
+        "params": {
+          "controller_enabled": true
+        },
+        "ports": []
+      },
+      "host_genesis_state": {
+        "active_channels": [],
+        "interchain_accounts": [],
+        "params": {
+          "allow_messages": [
+            "/terra.*",
+            "/ibc.*",
+            "/cosmos.[a-rt-z]*",
+            "/cosmos.s[a-su-z]*"
+          ],
+          "host_enabled": true
+        },
+        "port": "icahost"
+      }
+    },
+    "feeibc": {
+      "identified_fees": [],
+      "fee_enabled_channels": [],
+      "registered_payees": [],
+      "registered_counterparty_payees": [],
+      "forward_relayers": []
     },
     "market": {
       "params": {


### PR DESCRIPTION
- Change chainID (`chain_id`) to `columbus-5`
  - `classic-terra/core` has [validator power limits if `ctx.ChainID() == ColumbusChainID`, so we fork it.](https://github.com/mint-cash/terra-classic-cosmos-sdk/commit/9ff63e0be7c466cf36b0cd2bd095d2cf972cd819)
- Update `genesis.json` to pass `terrad validate-genesis`
  - Add missing module params for `ibc.connection_genesis.params.max_expected_time_per_block`, `interchainaccounts`, and `feeibc`
  - Update `genutil.gen_txs.[{signatures}]` because we're changing `chain_id` and `body.messages.[{description.moniker}]` -- generate new signature with [`terrad gentx`](https://docs.terra.money/develop/terrad/commands/terrad_gentx/) using the `validator` wallet.
- Rewrite of PR #11 